### PR TITLE
[BUGFIX] Handle VIP guests in `guestlist:list-loaded` event handler

### DIFF
--- a/assets/js/guest-list.js
+++ b/assets/js/guest-list.js
@@ -18,6 +18,8 @@ document.addEventListener('DOMContentLoaded', function () {
     const guestListTableBody = document.querySelector(SELECTOR_GUEST_LIST_TABLE + ' tbody');
     const eventId = parseInt(guestListTable.dataset.eventId, 10);
 
+    guestListTable.addEventListener('guestlist:list-loaded', handleLoadedGuestList);
+
     fetch('/json/' + eventId + '/guests', {
         credentials: 'same-origin'
     }).then(async function (response) {
@@ -29,7 +31,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 rows.appendChild(guestRow);
             }
             guestListTableBody.appendChild(rows);
-            document.dispatchEvent(new CustomEvent('guestlist:list-loaded'));
+            guestListTable.dispatchEvent(new CustomEvent('guestlist:list-loaded'));
         })
     });
 
@@ -61,7 +63,13 @@ document.addEventListener('DOMContentLoaded', function () {
     }, 150));
 });
 
-document.addEventListener('guestlist:list-loaded', function () {
+function handleLoadedGuestList(e) {
+    // Change color based on VIP status
+    e.target.querySelectorAll('[data-vip="true"]').forEach(function(vipRow) {
+        vipRow.classList.replace('text-white', 'text-warning')
+        vipRow.classList.add('bg-vip');
+    });
+
     const searchInput = document.querySelector(SELECTOR_SEARCH_INPUT);
     searchInput.disabled = false;
 
@@ -191,7 +199,7 @@ document.addEventListener('guestlist:list-loaded', function () {
             });
         }
     });
-});
+}
 
 function loadStats(event) {
     fetch('/json/stats/' + event, {
@@ -229,12 +237,6 @@ function handleAjaxError(data) {
 
 function injectData(dataValues, domNode) {
     // Fill data attributes with dotted values
-    // Change Color based on VIP status
-    if (dataValues.vip) {
-        domNode.classList.remove('text-white');
-        domNode.classList.add('text-warning');
-        domNode.classList.add('bg-vip');
-    }
     const rootNode = domNode.getRootNode();
     if (rootNode !== document) {
         for (const attribute of rootNode.getAttributeNames()) {

--- a/templates/guest_list/event.html.twig
+++ b/templates/guest_list/event.html.twig
@@ -54,7 +54,7 @@
     <hr>
 
     <template id="guest-list-row-not-checked-in">
-        <tr data-guest-id=".id" data-first-name=".firstName" data-last-name=".lastName" data-pluses=".pluses" data-check-in=".checkInTimestamp" class="text-white">
+        <tr data-guest-id=".id" data-first-name=".firstName" data-last-name=".lastName" data-pluses=".pluses" data-check-in=".checkInTimestamp" data-vip=".vip" class="text-white">
             <td class="align-middle" data-col="firstName" data-value="firstName"></td>
             <td class="align-middle" data-col="lastName" data-value="lastName"></td>
             <td class="align-middle" data-col="pluses"></td>
@@ -68,7 +68,7 @@
     </template>
 
     <template id="guest-list-row-checked-in">
-        <tr data-guest-id=".id" data-first-name=".firstName" data-last-name=".lastName" data-pluses=".pluses" data-check-in=".checkInTimestamp" class="row-checked-in bg-danger text-white">
+        <tr data-guest-id=".id" data-first-name=".firstName" data-last-name=".lastName" data-pluses=".pluses" data-check-in=".checkInTimestamp" data-vip=".vip" class="row-checked-in bg-danger text-white">
             <td class="align-middle" data-col="firstName" data-value="firstName"></td>
             <td class="align-middle" data-col="lastName" data-value="lastName"></td>
             <td class="align-middle" data-col="pluses"></td>


### PR DESCRIPTION
Previously, the CSS classes of rows representing VIP guests were changed
in a global, low level, place being a no-op in most cases.

The event handler for `guestlist:list-loaded` is moved into a
separate function which allows dispatching the event on the guestlist
table only. Finally, the VIP handling is now done in that extracted event
handler.