### PR TITLE
[TASK] Change default sorting and add tablesort library

### DIFF
--- a/assets/js/guest-list.js
+++ b/assets/js/guest-list.js
@@ -1,3 +1,4 @@
+import Tablesort from 'tablesort/dist/tablesort.min';
 import Modal from 'bootstrap/js/dist/modal';
 
 const SELECTOR_GUEST_LIST_TABLE = '#guest-list-table';
@@ -42,7 +43,6 @@ document.addEventListener('DOMContentLoaded', function () {
 
         currentGuestRow.replaceWith(computedGuestRow);
         loadStats(event.detail.data.event);
-        sortRows();
         showHideCheckedInRow();
     });
 
@@ -63,7 +63,11 @@ document.addEventListener('DOMContentLoaded', function () {
     }, 150));
 });
 
-function handleLoadedGuestList() {
+function handleLoadedGuestList(e) {
+    new Tablesort(e.target, {
+        descending: true
+    });
+
     const searchInput = document.querySelector(SELECTOR_SEARCH_INPUT);
     searchInput.disabled = false;
 
@@ -295,36 +299,6 @@ function composeGuestRow(data) {
     }
 
     return rowFromTemplate;
-}
-
-function sortRows() {
-    const rowSorter = function (row1, row2) {
-        const checkInTimestamp1 = row1.dataset.checkIn;
-        const checkInTimestamp2 = row2.dataset.checkIn;
-        const firstName1 = row1.dataset.firstName;
-        const firstName2 = row2.dataset.firstName;
-        const lastName1 = row1.dataset.lastName;
-        const lastName2 = row2.dataset.lastName;
-
-        let result = checkInTimestamp1 - checkInTimestamp2;
-        if (result === 0) {
-            result = firstName1.localeCompare(firstName2);
-            if (result === 0) {
-                result = lastName1.localeCompare(lastName2);
-            }
-        }
-
-        return result;
-    };
-    const guestListTableBody = document.querySelector(SELECTOR_GUEST_LIST_TABLE + ' tbody');
-    const rows = Array.from(guestListTableBody.querySelectorAll('tr[data-first-name][data-last-name]'));
-    rows.sort(rowSorter);
-
-    const intermediateTableContents = document.createDocumentFragment();
-    const intermediateTableBody = document.createElement('tbody');
-    intermediateTableContents.appendChild(intermediateTableBody);
-    intermediateTableBody.append(...rows);
-    guestListTableBody.replaceWith(intermediateTableContents);
 }
 
 function showHideCheckedInRow() {

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -39,6 +39,8 @@ $input-group-addon-border-color: $gray-900;
 @import "~bootstrap/scss/utilities/api";
 @import "~bootstrap/scss/grid";
 
+@import "./modules/tablesort";
+
 .bg-vip {
   background-image: linear-gradient(45deg,rgba(255,255,255,.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,.15) 50%,rgba(255,255,255,.15) 75%,transparent 75%,transparent);
   background-size: 1rem 1rem;

--- a/assets/styles/modules/tablesort.scss
+++ b/assets/styles/modules/tablesort.scss
@@ -1,0 +1,35 @@
+th[role=columnheader]:not([data-sort-method="none"]):not(.no-sort) {
+  cursor: pointer;
+
+  &:after {
+    content: '';
+    float: right;
+    margin-top: calc(1em - 6px);
+    border-color: $white transparent;
+    visibility: hidden;
+    opacity: 0;
+    -ms-user-select: none;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    user-select: none;
+  }
+
+  &:hover:after {
+    visibility: visible;
+    opacity: 1;
+  }
+}
+
+th[aria-sort]:not([data-sort-method="none"]):not(.no-sort):after {
+  visibility: visible;
+  opacity: 0.4;
+  border-style: solid;
+}
+
+th[aria-sort=ascending]:not([data-sort-method="none"]):not(.no-sort):after {
+  border-width: 0 4px 4px;
+}
+
+th[aria-sort=descending]:not([data-sort-method="none"]):not(.no-sort):after {
+  border-width: 4px 4px 0;
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     },
     "dependencies": {
         "@popperjs/core": "^2.11.5",
-        "bootstrap": "^5.1.3"
+        "bootstrap": "^5.1.3",
+        "tablesort": "^5.3.0"
     }
 }

--- a/src/Entity/Event.php
+++ b/src/Entity/Event.php
@@ -26,7 +26,7 @@ class Event
 
     /**
      * @ORM\OneToMany(targetEntity=Guest::class, mappedBy="event", cascade={"persist"})
-     * @ORM\OrderBy({"checkInTime" = "ASC", "lastName" = "ASC", "firstName" = "ASC"})
+     * @ORM\OrderBy({"firstName"="ASC", "lastName"="ASC"})
      */
     private $guests;
 

--- a/templates/guest_list/event.html.twig
+++ b/templates/guest_list/event.html.twig
@@ -40,11 +40,11 @@
     <table class="table my-4" id="guest-list-table" data-event-id="{{ event.id }}">
         <thead>
             <tr class="text-white text-uppercase bg-secondary">
-                <th id="sorter-firstname">First Name</th>
-                <th id="sorter-lastname">Last Name</th>
-                <th>Pluses</th>
-                <th>Checked In</th>
-                <th></th>
+                <th>First Name</th>
+                <th>Last Name</th>
+                <th data-sort-method="none">Pluses</th>
+                <th data-sort-method="none">Checked In</th>
+                <th data-sort-method="none"></th>
             </tr>
         </thead>
         <tbody>
@@ -54,7 +54,7 @@
     <hr>
 
     <template id="guest-list-row-not-checked-in">
-        <tr data-guest-id=".id" data-first-name=".firstName" data-last-name=".lastName" data-pluses=".pluses" data-check-in=".checkInTimestamp" class="text-white">
+        <tr data-guest-id=".id" data-first-name=".firstName" data-last-name=".lastName" data-pluses=".pluses" class="text-white">
             <td class="align-middle" data-col="firstName" data-value="firstName"></td>
             <td class="align-middle" data-col="lastName" data-value="lastName"></td>
             <td class="align-middle" data-col="pluses"></td>
@@ -68,7 +68,7 @@
     </template>
 
     <template id="guest-list-row-checked-in">
-        <tr data-guest-id=".id" data-first-name=".firstName" data-last-name=".lastName" data-pluses=".pluses" data-check-in=".checkInTimestamp" class="row-checked-in bg-danger text-white">
+        <tr data-guest-id=".id" data-first-name=".firstName" data-last-name=".lastName" data-pluses=".pluses" class="row-checked-in bg-danger text-white">
             <td class="align-middle" data-col="firstName" data-value="firstName"></td>
             <td class="align-middle" data-col="lastName" data-value="lastName"></td>
             <td class="align-middle" data-col="pluses"></td>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4228,6 +4228,11 @@ sync-rpc@^1.3.6:
   dependencies:
     get-port "^3.1.0"
 
+tablesort@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/tablesort/-/tablesort-5.3.0.tgz#899534f40f5395c1ec4d00f7b9d026c6e21ccc3f"
+  integrity sha512-WkfcZBHsp47gVH9CBHG0ZXopriG01IA87arGrchvIe868d4RiXVvoYPS1zMq9IdW05kBs5iGsqxTABqLyWonbg==
+
 tapable@^2.1.1, tapable@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"


### PR DESCRIPTION
The default sorting of guests is changed to firstName=ASC, lastName=ASC,
the check-in date is not taken into account anymore, which renders the
manual table sorting being applied after updating a guest obsolete and is
removed.
    
The library `tablesort` is added to enable sorting the table by clicking
a table header, which is enabled for "first name" and "last name".
